### PR TITLE
Return x402 402 responses on protected paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Bootstrap Cloudflare Worker for the x402 payment gateway MVP.
 
 ## Setup
 1. Install dependencies: `npm install`
-2. Update `wrangler.jsonc` variables if you need a different upstream base URL or protected prefix.
+2. Update `wrangler.jsonc` variables if you need a different upstream base URL, protected prefix, or payment offer defaults (price, currency, network, receiver, timeout).
 3. Start local dev server: `npm run dev`
-4. Visit `http://localhost:8787/api/anything` to proxy through to the configured upstream (`https://httpbin.org` by default).
+4. Visit `http://localhost:8787/api/anything` to see a 402 Payment Required response without payment headers, or hit an unprotected path like `/health` to see proxying to the upstream (`https://httpbin.org` by default).
 
 ## Deploy
 - Run `npm run deploy` when ready. Wrangler will prompt for authentication if necessary.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,117 @@
 interface Env {
 	UPSTREAM_BASE: string;
-	PROTECT_PREFIX: string;
+	PROTECT_PREFIX?: string;
+	PRICE_USDC_MICRO?: string;
+	CURRENCY?: string;
+	NETWORK?: string;
+	ASSET?: string;
+	RECEIVER?: string;
+	TIMEOUT_SECS?: string;
 }
 
-const DEFAULT_PREFIX = "/api/";
+const DEFAULT_PREFIX = '/api/';
+const DEFAULT_PRICE_MICROS = '10000';
+const DEFAULT_CURRENCY = 'USDC';
+const DEFAULT_NETWORK = 'base-mainnet';
+const DEFAULT_ASSET = 'USDC';
+const DEFAULT_RECEIVER = '0x0000000000000000000000000000000000000000';
+const DEFAULT_TIMEOUT_SECONDS = 60;
 
 function normalizePrefix(prefix?: string) {
-	const safe = prefix?.trim();
-	return safe && safe.startsWith("/") ? safe : DEFAULT_PREFIX;
+	const trimmed = prefix?.trim();
+	if (!trimmed) return DEFAULT_PREFIX;
+	return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
 function buildUpstreamRequest(request: Request, upstreamBase: string) {
 	const incoming = new URL(request.url);
 	const target = new URL(incoming.pathname + incoming.search, upstreamBase);
-	return new Request(target, request);
+	return new Request(target.toString(), request);
+}
+
+function parseTimeout(value?: string) {
+	const parsed = Number.parseInt(value ?? '', 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_SECONDS;
+}
+
+function formatMicrosToDecimal(micros: string) {
+	if (!/^[0-9]+$/.test(micros)) {
+		return '0';
+	}
+
+	const value = BigInt(micros);
+	const whole = value / 1_000_000n;
+	const fraction = value % 1_000_000n;
+	if (fraction === 0n) {
+		return whole.toString();
+	}
+
+	const fractionStr = fraction.toString().padStart(6, '0').replace(/0+$/, '');
+	return `${whole.toString()}.${fractionStr}`;
+}
+
+function buildPaymentOffer(env: Env, prefix: string) {
+	const priceMicros = env.PRICE_USDC_MICRO ?? DEFAULT_PRICE_MICROS;
+	const priceDecimal = formatMicrosToDecimal(priceMicros);
+	const currency = env.CURRENCY ?? DEFAULT_CURRENCY;
+	const network = env.NETWORK ?? DEFAULT_NETWORK;
+	const asset = env.ASSET ?? DEFAULT_ASSET;
+	const receiver = env.RECEIVER ?? DEFAULT_RECEIVER;
+	const timeout = parseTimeout(env.TIMEOUT_SECS);
+	const orderId = crypto.randomUUID();
+
+	return {
+		x402Version: 1,
+		price: priceDecimal,
+		currency,
+		network,
+		receiver,
+		orderId,
+		maxTimeoutSeconds: timeout,
+		accepts: [
+			{
+				scheme: 'exact',
+				network,
+				asset,
+				maxAmountRequired: priceMicros,
+				payTo: receiver,
+				resource: `${prefix}*`,
+				description: `Access ${prefix} endpoints`,
+				mimeType: 'application/json',
+				maxTimeoutSeconds: timeout,
+				orderId,
+			},
+		],
+	};
+}
+
+function paymentRequiredResponse(offer: ReturnType<typeof buildPaymentOffer>) {
+	return new Response(JSON.stringify(offer), {
+		status: 402,
+		headers: {
+			'content-type': 'application/json',
+			'cache-control': 'no-store',
+		},
+	});
 }
 
 export default {
 	async fetch(request, env): Promise<Response> {
 		const upstreamBase = env.UPSTREAM_BASE;
-
 		if (!upstreamBase) {
-			return new Response("UPSTREAM_BASE is not configured", { status: 500 });
+			return new Response('UPSTREAM_BASE is not configured', { status: 500 });
 		}
 
-		const prefix = normalizePrefix(env.PROTECT_PREFIX);
-		const url = new URL(request.url);
-		const protectedPath = url.pathname.startsWith(prefix);
+	const prefix = normalizePrefix(env.PROTECT_PREFIX);
+	const url = new URL(request.url);
+	const isProtected = url.pathname.startsWith(prefix);
 
-		// WW-74: Always proxy to upstream. Payment checks will be added in follow-up tasks.
-		const upstreamRequest = buildUpstreamRequest(request, upstreamBase);
+	if (isProtected && !request.headers.has('X-PAYMENT')) {
+		const offer = buildPaymentOffer(env, prefix);
+		return paymentRequiredResponse(offer);
+	}
 
-		if (!protectedPath) {
-			return fetch(upstreamRequest);
-		}
-
-		return fetch(upstreamRequest);
+	const upstreamRequest = buildUpstreamRequest(request, upstreamBase);
+	return fetch(upstreamRequest);
 	},
 } satisfies ExportedHandler<Env>;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,11 +2,17 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import worker from '../src/index';
 
 type TestEnv = {
-	UPSTREAM_BASE: string;
-	PROTECT_PREFIX: string;
+	UPSTREAM_BASE?: string;
+	PROTECT_PREFIX?: string;
+	PRICE_USDC_MICRO?: string;
+	CURRENCY?: string;
+	NETWORK?: string;
+	ASSET?: string;
+	RECEIVER?: string;
+	TIMEOUT_SECS?: string;
 };
 
-describe('Proxy worker scaffold', () => {
+describe('Payment-gated proxy scaffold', () => {
 	const originalFetch = globalThis.fetch;
 	let env: TestEnv;
 
@@ -14,6 +20,12 @@ describe('Proxy worker scaffold', () => {
 		env = {
 			UPSTREAM_BASE: 'https://upstream.example',
 			PROTECT_PREFIX: '/api/',
+			PRICE_USDC_MICRO: '10000',
+			CURRENCY: 'USDC',
+			NETWORK: 'base-mainnet',
+			ASSET: 'USDC',
+			RECEIVER: '0xabc',
+			TIMEOUT_SECS: '60',
 		};
 	});
 
@@ -32,33 +44,75 @@ describe('Proxy worker scaffold', () => {
 
 		expect(await response.text()).toBe('upstream echo');
 		expect(fetchMock).toHaveBeenCalledOnce();
-		expect(fetchMock.mock.calls[0]?.[0]).toBeInstanceOf(Request);
 		expect((fetchMock.mock.calls[0]?.[0] as Request).url).toBe('https://upstream.example/health');
 	});
 
-	it('proxies protected paths (payment enforcement comes later)', async () => {
-		const upstreamResponse = new Response('protected upstream', { status: 200 });
-		const fetchMock = vi.fn().mockResolvedValue(upstreamResponse);
+	it('returns x402 offer when protected path lacks payment header', async () => {
+		const randomSpy = vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue('order-test');
+		const fetchMock = vi.fn();
 		globalThis.fetch = fetchMock;
 
 		const request = new Request('http://example.com/api/hello');
 		const response = await worker.fetch(request, env as any, {} as any);
 
+		expect(response.status).toBe(402);
+		expect(response.headers.get('content-type')).toContain('application/json');
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		const body = await response.json();
+		expect(body).toMatchObject({
+			x402Version: 1,
+			price: '0.01',
+			currency: 'USDC',
+			network: 'base-mainnet',
+			receiver: '0xabc',
+			orderId: 'order-test',
+			maxTimeoutSeconds: 60,
+		});
+		expect(Array.isArray(body.accepts)).toBe(true);
+		expect(body.accepts[0]).toMatchObject({
+			scheme: 'exact',
+			network: 'base-mainnet',
+			asset: 'USDC',
+			maxAmountRequired: '10000',
+			payTo: '0xabc',
+			resource: '/api/*',
+			orderId: 'order-test',
+			maxTimeoutSeconds: 60,
+		});
+		expect(randomSpy).toHaveBeenCalledOnce();
+	});
+
+	it('proxies protected paths when payment header is present', async () => {
+		const upstreamResponse = new Response('protected upstream', { status: 200 });
+		const fetchMock = vi.fn().mockResolvedValue(upstreamResponse);
+		globalThis.fetch = fetchMock;
+
+		const request = new Request('http://example.com/api/hello', {
+			headers: { 'X-PAYMENT': 'stub' },
+		});
+		const response = await worker.fetch(request, env as any, {} as any);
+
 		expect(await response.text()).toBe('protected upstream');
 		expect(fetchMock).toHaveBeenCalledOnce();
-		expect(fetchMock.mock.calls[0]?.[0]).toBeInstanceOf(Request);
 		expect((fetchMock.mock.calls[0]?.[0] as Request).url).toBe('https://upstream.example/api/hello');
 	});
 
-	it('returns 500 when upstream base is missing', async () => {
-		const fetchMock = vi.fn();
-		globalThis.fetch = fetchMock;
+	it('emits unique orderId per payment offer', async () => {
+		vi.spyOn(globalThis.crypto, 'randomUUID')
+			.mockReturnValueOnce('order-one')
+			.mockReturnValueOnce('order-two');
 
-		const request = new Request('http://example.com/api/hello');
-		const response = await worker.fetch(request, { PROTECT_PREFIX: '/api/' } as any, {} as any);
+		const first = await worker.fetch(new Request('http://example.com/api/a'), env as any, {} as any);
+		const second = await worker.fetch(new Request('http://example.com/api/b'), env as any, {} as any);
 
-		expect(response.status).toBe(500);
-		expect(await response.text()).toContain('UPSTREAM_BASE');
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(first.status).toBe(402);
+		expect(second.status).toBe(402);
+
+		const firstBody = await first.json();
+		const secondBody = await second.json();
+		expect(firstBody.orderId).toBe('order-one');
+		expect(secondBody.orderId).toBe('order-two');
+		expect(firstBody.orderId).not.toBe(secondBody.orderId);
 	});
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,7 +9,13 @@
 	"compatibility_date": "2025-09-18",
 	"vars": {
 		"UPSTREAM_BASE": "https://httpbin.org",
-		"PROTECT_PREFIX": "/api/"
+		"PROTECT_PREFIX": "/api/",
+		"PRICE_USDC_MICRO": "10000",
+		"CURRENCY": "USDC",
+		"NETWORK": "base-mainnet",
+		"ASSET": "USDC",
+		"RECEIVER": "0x0000000000000000000000000000000000000000",
+		"TIMEOUT_SECS": "60"
 	},
 	"observability": {
 		"enabled": true


### PR DESCRIPTION
## Summary
- emit x402-compliant 402 offers on protected routes missing payment evidence
- surface configurable payment defaults via wrangler vars and helper utilities
- document updated behavior and cover with unit tests for 402 and proxy flows

## Testing
- npm run test -- --run
